### PR TITLE
Fix integer parser

### DIFF
--- a/Lightyear/Strings.idr
+++ b/Lightyear/Strings.idr
@@ -77,9 +77,7 @@ integer = do minus <- opt (char '-')
                Nothing => pure (fromInteger theInt)
                Just () => pure (fromInteger ((-1) * theInt))
   where getInteger : List (Fin 10) -> Integer
-        getInteger []      = 0 -- will never happen because "some" always finds at least one elt
-        getInteger [d]     = cast d
-        getInteger (d::ds) = 10 * cast d + getInteger ds
+        getInteger = foldl (\a => \b => 10 * a + cast b) 0
 
 
 


### PR DESCRIPTION
Before this, the number 1234 was parsed as 64 = 10_1 + 10_2 + 10*3 + 4:

```
*Lightyear/Strings> :x test integer "1234"
MkIO (\ w => prim_io_return (Just 64)) : IO (Maybe Integer)
```
