### PR TITLE
Switch to continuation-passing-style implementation

### DIFF
--- a/Lightyear/Strings.idr
+++ b/Lightyear/Strings.idr
@@ -23,9 +23,9 @@ Parser : Type -> Type
 Parser = ParserT Identity String
 
 parse : Parser a -> String -> Either String a
-parse (PT f) s = let Id r = f s in case r of
-  Success _ x  => Right x
-  Failure _ es => Left $ formatError s es
+parse f s = let Id r = execParserT f s in case r of
+  Success _ x => Right x
+  Failure es  => Left $ formatError s es
 
 private
 uncons : String -> Maybe (Char, String)


### PR DESCRIPTION
With this, the stack doesn't grow with every use of `<|>`, and alternatives are forgotten once we have committed to one branch. This should improve space usage and enable parsing of large documents without a stack overflow. I tested this new implementation with Bibdris. Performance seems to be on par with the old implementation.
