### PR TITLE
Fixed visiblity.

### DIFF
--- a/examples/Json.idr
+++ b/examples/Json.idr
@@ -1,10 +1,12 @@
 module Json
 
-import Lightyear.Core
-import Lightyear.Combinators
-import Lightyear.Strings
+import public Control.Monad.Identity
 
-import Data.SortedMap
+import public Lightyear.Core
+import public Lightyear.Combinators
+import public Lightyear.Strings
+
+import public Data.SortedMap
 
 %access public
 

--- a/tests/Test.idr
+++ b/tests/Test.idr
@@ -1,5 +1,7 @@
 module Main
 
+import Control.Monad.Identity
+
 import Lightyear.Core
 import Lightyear.Combinators
 import Lightyear.Strings


### PR DESCRIPTION
Commit [#7b5f](https://github.com/idris-lang/Idris-dev/commit/7b5f4aa392985c6a7d7fdd5268cebe4adee954b8) of Idris introduces new import and export rules.
This commit updates Lightyear to be compliant with upstream idris changes.

The changes made to lightyear assume that to use lighteyar you must use the following import statements.

``` idris
import public Control.Monad.Identity

import public Lightyear.Core
import public Lightyear.Combinators
import public Lightyear.Strings
```

Library designers can then hide their use of Lightyear from their consumers.
