### PR TITLE
Refactor Lightyear.String to Lightyear.Char and add missing functionality

### DIFF
--- a/Lightyear/Char.idr
+++ b/Lightyear/Char.idr
@@ -1,0 +1,134 @@
+-- ------------------------------------------------------------- [ Char.idr ]
+-- Module      : Lightyear.Char
+-- Description : Character-related parsers.
+--
+-- This code is distributed under the BSD 2-clause license.
+-- See the file LICENSE in the root directory for its full text.
+--
+-- This code is (mostly) a port of Daan Leijen's Text.Parsec.Char library.
+-- --------------------------------------------------------------------- [ EOH ]
+module Lightyear.Char
+
+import public Data.Vect
+import public Data.Fin
+
+import public Control.Monad.Identity
+
+import Lightyear.Core
+import Lightyear.Combinators
+import Lightyear.Errmsg
+
+%access public
+
+||| A parser that matches some particular character
+char : (Monad m, Stream Char str) => Char -> ParserT m str Char
+char c = satisfy (== c) <?> "character '" ++ singleton c ++ "'"
+
+||| oneOf cs succeeds if the current character is in the supplied
+||| list of characters @cs@. Returns the parsed character. See also
+||| 'satisfy'.
+|||
+|||   vowel  = oneOf "aeiou"
+oneOf :  (Monad m, Stream Char str) => String -> ParserT m str Char
+oneOf cs = satisfy (\c => elem c $ unpack cs)
+
+||| As the dual of 'oneOf', @noneOf cs@ succeeds if the current
+||| character /not/ in the supplied list of characters @cs@. Returns the
+||| parsed character.
+|||
+|||  consonant = noneOf "aeiou"
+noneOf :  (Monad m, Stream Char str) => String -> ParserT m str Char
+noneOf cs = satisfy (\c => not $ elem c $ unpack cs)
+
+||| Parses a white space character (any character which satisfies 'isSpace')
+||| Returns the parsed character.
+space : (Monad m, Stream Char s) => ParserT m s Char
+space               = satisfy isSpace       <?> "space"
+
+||| Skips /zero/ or more white space characters. See also 'skipMany'.
+spaces : (Monad m, Stream Char s) => ParserT m s ()
+spaces              = skip (many Lightyear.Char.space)  <?> "white space"
+
+||| Parses a newline character (\'\\n\'). Returns a newline character. 
+newline : (Monad m, Stream Char s) => ParserT m s Char
+newline = char '\n' <?> "lf new-line"
+
+||| Parses a carriage return character (\'\\r\') followed by a newline character (\'\\n\').
+||| Returns a newline character. 
+crlf : (Monad m, Stream Char s) => ParserT m s Char
+crlf                = char '\r' *> char '\n' <?> "crlf new-line"
+
+||| Parses a CRLF (see 'crlf') or LF (see 'newline') end-of-line.
+||| Returns a newline character (\'\\n\').
+|||
+||| endOfLine = newline <|> crlf
+endOfLine : (Monad m, Stream Char s) => ParserT m s Char
+endOfLine           = newline <|> crlf       <?> "new-line"
+
+||| Parses a tab character (\'\\t\'). Returns a tab character. 
+tab : (Monad m, Stream Char s) => ParserT m s Char
+tab                 = char '\t'             <?> "tab"
+
+||| Parses an upper case letter (a character between \'A\' and \'Z\').
+||| Returns the parsed character. 
+upper : (Monad m, Stream Char s) => ParserT m s Char
+upper               = satisfy isUpper       <?> "uppercase letter"
+
+||| Parses a lower case character (a character between \'a\' and \'z\').
+||| Returns the parsed character. 
+lower : (Monad m, Stream Char s) => ParserT m s Char
+lower               = satisfy isLower       <?> "lowercase letter"
+
+||| Parses a letter or digit (a character between \'0\' and \'9\').
+||| Returns the parsed character. 
+
+alphaNum : (Monad m, Stream Char s) => ParserT m s Char
+alphaNum            = satisfy isAlphaNum    <?> "letter or digit"
+
+||| Parses a letter (an upper case or lower case character). Returns the
+||| parsed character. 
+letter : (Monad m, Stream Char s) => ParserT m s Char
+letter              = satisfy isAlpha       <?> "letter"
+
+||| Matches a single digit
+digit : (Monad m, Stream Char s) => ParserT m s (Fin 10)
+digit = satisfyMaybe fromChar
+  where fromChar : Char -> Maybe (Fin 10)
+        fromChar '0' = Just FZ
+        fromChar '1' = Just (FS (FZ))
+        fromChar '2' = Just (FS (FS (FZ)))
+        fromChar '3' = Just (FS (FS (FS (FZ))))
+        fromChar '4' = Just (FS (FS (FS (FS (FZ)))))
+        fromChar '5' = Just (FS (FS (FS (FS (FS (FZ))))))
+        fromChar '6' = Just (FS (FS (FS (FS (FS (FS (FZ)))))))
+        fromChar '7' = Just (FS (FS (FS (FS (FS (FS (FS (FZ))))))))
+        fromChar '8' = Just (FS (FS (FS (FS (FS (FS (FS (FS (FZ)))))))))
+        fromChar '9' = Just (FS (FS (FS (FS (FS (FS (FS (FS (FS (FZ))))))))))
+        fromChar _   = Nothing
+
+||| Matches an integer literal
+integer : (Num n, Monad m, Stream Char s) => ParserT m s n
+integer = do minus <- opt (char '-')
+             ds <- some digit
+             let theInt = getInteger ds
+             case minus of
+               Nothing => pure (fromInteger theInt)
+               Just _  => pure (fromInteger ((-1) * theInt))
+  where getInteger : List (Fin 10) -> Integer
+        getInteger = foldl (\a => \b => 10 * a + cast b) 0
+
+
+
+||| Parses a hexadecimal digit (a digit or a letter between \'a\' and
+||| \'f\' or \'A\' and \'F\'). Returns the parsed character. 
+hexDigit : (Monad m, Stream Char s) => ParserT m s Char
+hexDigit            = satisfy isHexDigit    <?> "hexadecimal digit"
+
+||| Parses an octal digit (a character between \'0\' and \'7\'). Returns
+||| the parsed character. 
+octDigit : (Monad m, Stream Char s) => ParserT m s Char
+octDigit            = satisfy isOctDigit    <?> "octal digit"
+
+||| This parser succeeds for any character. Returns the parsed character. 
+anyChar : (Monad m, Stream Char s) => ParserT m s Char
+anyChar             = satisfy (const True)

--- a/Lightyear/Strings.idr
+++ b/Lightyear/Strings.idr
@@ -16,6 +16,8 @@ import Lightyear.Core
 import Lightyear.Combinators
 import Lightyear.Errmsg
 
+import Lightyear.Char
+
 %access public
 
 -- -------------------------------------------------------- [ Helper Functions ]
@@ -45,23 +47,15 @@ instance Stream Char String where
 
 -- ---------------------------------------------------------- [ Reserved Stuff ]
 
-||| A parser that matches some particular character
-char : Monad m => Char -> ParserT m String Char
-char c = satisfy (== c) <?> "character '" ++ singleton c ++ "'"
-
 ||| A parser that matches a particular string
 string : Monad m => String -> ParserT m String String
 string s = pack <$> (traverse char $ unpack s) <?> "string " ++ show s
 
 -- ------------------------------------------------------------------- [ Space ]
 
-||| A parser that skips whitespace
-space : Monad m => ParserT m String ()
-space = skip (many $ satisfy isSpace) <?> "whitespace"
-
 ||| A simple lexer that strips white space from tokens
 lexeme : Monad m => ParserT m String a -> ParserT m String a
-lexeme p = p <* space
+lexeme p = p <* spaces
 
 -- ------------------------------------------------------------------ [ Tokens ]
 
@@ -133,35 +127,6 @@ semiSep1 p = p `sepBy1` semi
 ||| Parses /zero/ or more occurrences of `p` separated by `semi`.
 semiSep : Monad m => ParserT m String a -> ParserT m String (List a)
 semiSep p = p `sepBy` semi
-
--- ----------------------------------------------------------------- [ Numbers ]
-
-||| Matches a single digit
-digit : Monad m => ParserT m String (Fin 10)
-digit = satisfyMaybe fromChar
-  where fromChar : Char -> Maybe (Fin 10)
-        fromChar '0' = Just FZ
-        fromChar '1' = Just (FS (FZ))
-        fromChar '2' = Just (FS (FS (FZ)))
-        fromChar '3' = Just (FS (FS (FS (FZ))))
-        fromChar '4' = Just (FS (FS (FS (FS (FZ)))))
-        fromChar '5' = Just (FS (FS (FS (FS (FS (FZ))))))
-        fromChar '6' = Just (FS (FS (FS (FS (FS (FS (FZ)))))))
-        fromChar '7' = Just (FS (FS (FS (FS (FS (FS (FS (FZ))))))))
-        fromChar '8' = Just (FS (FS (FS (FS (FS (FS (FS (FS (FZ)))))))))
-        fromChar '9' = Just (FS (FS (FS (FS (FS (FS (FS (FS (FS (FZ))))))))))
-        fromChar _   = Nothing
-
-||| Matches an integer literal
-integer : (Num n, Monad m) => ParserT m String n
-integer = do minus <- opt (char '-')
-             ds <- some digit
-             let theInt = getInteger ds
-             case minus of
-               Nothing => pure (fromInteger theInt)
-               Just _  => pure (fromInteger ((-1) * theInt))
-  where getInteger : List (Fin 10) -> Integer
-        getInteger = foldl (\a => \b => 10 * a + cast b) 0
 
 -- -------------------------------------------------------- [ Testing Function ]
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Module overview:
 * `Lightyear.Core`: central definitions + instances
 * `Lightyear.Errmsg`: error message formatting, mainly internal library
 * `Lightyear.Combinators`: generic combinators like `many` or `sepBy`
-* `Lightyear.Strings`: string-bound parsers like `char` or `space`
+* `Lightyear.Char`: char-bound parsers like `char` or `space`
+* `Lightyear.Strings`: string-bound parsers like `strings` or `lexeme`
 
 ## Synopsis
 

--- a/examples/Json.idr
+++ b/examples/Json.idr
@@ -1,6 +1,7 @@
 module Json
 
 import public Lightyear
+import public Lightyear.Char
 import public Lightyear.Strings
 
 import public Data.SortedMap
@@ -108,7 +109,7 @@ mutual
 
   keyValuePair : Parser (String, JsonValue)
   keyValuePair = do
-    key <- space *> jsonString <* space
+    key <- spaces *> jsonString <* spaces
     char ':'
     value <- jsonValue
     pure (key, value)
@@ -125,7 +126,7 @@ mutual
             <|>| map JsonObject jsonObject
 
   jsonValue : Parser JsonValue
-  jsonValue = space *> jsonValue' <* space
+  jsonValue = spaces *> jsonValue' <* spaces
 
 jsonToplevelValue : Parser JsonValue
 jsonToplevelValue = (map JsonArray jsonArray) <|> (map JsonObject jsonObject)

--- a/lightyear.ipkg
+++ b/lightyear.ipkg
@@ -5,3 +5,4 @@ modules = Lightyear.Core
 	, Lightyear.Errmsg
         , Lightyear
 	, Lightyear.Strings
+	, Lightyear.Char

--- a/tests/Test.idr
+++ b/tests/Test.idr
@@ -4,6 +4,7 @@ import Data.Vect
 import Data.Fin
 
 import Lightyear
+import Lightyear.Char
 import Lightyear.Strings
 
 test : Show a => Parser a -> String -> IO ()


### PR DESCRIPTION
This changes refactors some of the functions in Lightyear.Strings to a new module Lightyear.Char, to follow more closely the implementation of Daan Leijen's Parsec. Additionally it adds missing functionality from that library, found in Parsec.Text.Char.

I think there is a real benefit to be close to Daan's original library as it will make porting to and using Lightyear much easier.

All tests have been updated to account for these changes and run as expected.

This changelist is a set of breaking changes for earlier Lightyear users. The breaking changes are small and require adding an additional import:

      import Lightyear.Char

I think it is likely we would really want to factor out more from Lightyear.Strings, but I've left this to a future change.
