### PR TITLE
Fix runtests script for Mac OS X

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -2,6 +2,17 @@
 
 set -euo pipefail
 
+OS=`uname -s`
+
+# Timeout on Mac OS X is installed via brew install coreutils and called gtimeout
+if [ "$OS" = "Darwin" ]; then
+	TIMEOUTCMD=gtimeout
+else
+	TIMEOUTCMD=timeout
+fi
+
+echo "TIMOUTCMD set to ${TIMEOUTCMD}"
+
 die() {
 	echo "$1" >&2
 	exit 1
@@ -17,15 +28,16 @@ echo "compiling lightyear tests..."
 idris Test.idr -p lightyear -o test || die "* could not compile tests *"
 
 echo "compiled OK, running lightyear tests..."
-timeout 5s ./test > output || die "* test failed or timed out *"
+$TIMEOUTCMD 5s ./test > output || die "* test failed or timed out *"
 
 echo "compiling the JSON test..."
 idris JsonTest.idr -p lightyear -p contrib -o json || die "* could not compile the json test *"
 
 echo "compiled OK, running the JSON test..."
-timeout 5s ./json >> output || die "* test failed or timed out *"
+$TIMEOUTCMD 5s ./json >> output || die "* test failed or timed out *"
 
-if [ "$1" = "believe_me" ]; then
+# use a default parameter if $1 is not set
+if [ "${1-}" = "believe_me" ]; then
 	echo '### marking current output as expected ###'
 	cat output > expected
 	clean_up


### PR DESCRIPTION
timeout is called gtimeout on Mac OS X
