### PR TITLE
Improve Testing.

### DIFF
--- a/Lightyear/Testing.idr
+++ b/Lightyear/Testing.idr
@@ -1,0 +1,181 @@
+-- ------------------------------------------------------------- [ Char.idr ]
+-- Module      : Lightyear.Testing
+-- Description : Testing utilities.
+--
+-- This code is distributed under the BSD 2-clause license.
+-- See the file LICENSE in the root directory for its full text.
+--
+-- --------------------------------------------------------------------- [ EOH ]
+module Lightyear.Testing
+
+import Lightyear
+import Lightyear.Strings
+
+%access  export
+%default total
+
+||| Simple data structure to store the result of a parsing test.
+data TestReport : Type where
+  Pass : (title : String) -> TestReport
+
+  ParseFailure : (title : String)
+              -> (report : String)
+              -> TestReport
+
+  ResultFailure : (title : String) -> (made : String) -> TestReport
+
+  ||| Report a parsing failure with expected failure
+  AdvParseFailure : Show a
+                 => (title    : String)
+                 -> (input    : String)
+                 -> (expected : a)
+                 -> (report   : String)
+                 -> TestReport
+
+  ||| Report a wrong result failure with expected failure.
+  AdvResultFailure : Show a
+                 => (title    : String)
+                 -> (input    : String)
+                 -> (expected : a)
+                 -> (actual   : a)
+                 -> TestReport
+
+
+
+||| Run a parsing test that is expected to pass and discard result.
+|||
+||| @title    Name of the test.
+||| @p        The parser to test.
+||| @input    The input string to parse.
+parseTest : Show a
+         => (title    : String)
+         -> (p        : Parser a)
+         -> (input    : String)
+         -> TestReport
+parseTest title p input = do
+  case parse p input of
+    Left err     => ParseFailure title err
+    Right actual => Pass title
+
+||| Run a parsing test that is expected to fail and discard result.
+|||
+||| @title    Name of the test.
+||| @p        The parser to test.
+||| @input    The input string to parse.
+parseTestNot : Show a
+            => (title    : String)
+            -> (p        : Parser a)
+            -> (input    : String)
+            -> TestReport
+parseTestNot title p input = do
+  case parse p input of
+    Left err     => Pass title
+    Right actual => ResultFailure title (show actual)
+
+
+||| Run a parsing test that is expected to pass and compare result to
+||| an expected value.
+|||
+||| @title    Name of the test.
+||| @p        The parser to test.
+||| @input    The input string to parse.
+||| @expected The expected output from a successful parsing.
+||| @eq       A comparison function.
+parseTestCmp : Show a
+            => (title    : String)
+            -> (p        : Parser a)
+            -> (eq       : a -> a -> Bool)
+            -> (input    : String)
+            -> (expected : a)
+            -> TestReport
+parseTestCmp title p test input expected = do
+  case parse p input of
+    Left err     => AdvParseFailure title input expected err
+    Right actual => if test actual expected
+                      then Pass title
+                      else AdvResultFailure title input expected actual
+
+||| Run a parsing test that is expected to fail.
+|||
+||| @title    Name of the test.
+||| @p        The parser to test.
+||| @input    The input string to parse.
+||| @expected The expected parsing error message.
+parseTestCmpNot : Show a
+               => (title    : String)
+               -> (p        : Parser a)
+               -> (input    : String)
+               -> (expected : String)
+               -> TestReport
+parseTestCmpNot title p input expected = do
+  case parse p input of
+    Left actual  => if actual == expected
+                      then Pass title
+                      else AdvParseFailure title input expected actual
+    Right result => AdvResultFailure title input result result
+
+||| Run a parsing test that is expected to pass and compare showing
+||| the result to an expected value.
+|||
+||| @title    Name of the test.
+||| @p        The parser to test.
+||| @input    The input string to parse.
+||| @expected The expected output from a successful parsing.
+parseTestCmpShow : Show a
+                => (title    : String)
+                -> (p        : Parser a)
+                -> (input    : String)
+                -> (expected : String)
+                -> TestReport
+parseTestCmpShow title p input expected = do
+  case parse p input of
+    Left err     => ParseFailure title  err
+    Right actual => if show actual == expected
+                      then Pass title
+                      else ResultFailure title (show actual)
+
+||| Turn the test report into a string.
+private
+showReport : TestReport -> String
+showReport (Pass title) = unwords ["[PASS]", title]
+
+showReport (ParseFailure title report) =
+  unlines [ unwords ["[FAIL]", "[PARSING]", title]
+          , unwords ["\t", "Gave error:"]
+          , report
+          ]
+showReport (ResultFailure title made) =
+  unlines [ unwords ["[FAIL]", "[RESULT]", title]
+            , unwords ["\t", "I was able to parse, when I shouldn't and made:"]
+            , unwords ["\t\t", made]
+           ]
+
+showReport (AdvParseFailure title input expected report) =
+  unlines [ unwords ["[FAIL]", "[PARSING]", title]
+          , unwords ["\t", "Given input:"]
+          , unwords ["\t\t", input]
+          , unwords ["\t", "Gave error:"]
+          , report
+          ]
+showReport (AdvResultFailure title input expected actual) =
+    unlines $ head ++ footer
+  where
+    head = [ unwords ["[FAIL]", "[RESULT]", title]
+            , unwords ["\t", "Given input:"]
+            , unwords ["\t\t", input]
+           ]
+    footer = [ unwords ["\t", "I made:"]
+             , unwords ["\t\t", show actual]
+             , unwords ["\t", "But was expected to make:"]
+             , unwords ["\t\t", show expected]
+             ]
+
+||| Run an individual test.
+runTest : TestReport -> IO ()
+runTest = (putStrLn . showReport)
+
+||| Run a sequence of tests.
+runTests : List TestReport -> IO ()
+runTests = traverse_ runTest
+
+-- --------------------------------------------------------------------- [ EOF ]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install: build
 build: Lightyear/*.idr
 	idris --build lightyear.ipkg
 
-test: install
+test: build
 	(cd tests; bash runtests.sh)
 
 clean:

--- a/lightyear.ipkg
+++ b/lightyear.ipkg
@@ -12,3 +12,4 @@ modules = Lightyear
         , Lightyear.StringFile
         , Lightyear.Strings
         , Lightyear.Char
+        , Lightyear.Testing

--- a/tests/JsonTest.idr
+++ b/tests/JsonTest.idr
@@ -1,15 +1,46 @@
-module Main
+module JsonTest
 
 import Json
+
+import Lightyear.Testing
+
+%access export
 
 test : String -> IO ()
 test s = case parse jsonToplevelValue s of
   Left err => putStrLn $ "error: " ++ err
   Right v  => printLn v
 
-main : IO ()
-main = do
-  test "[1,2,4,[5,6],null,{\"some\":[\"object\"]},false]"
-  test "{\n  \"hallo\":42,\"nichts\":null}"
-  test "{{\n  \"hallo\":42,\"nichts\":null}"
-  test "{\"hello\": [{\"world\": false}, 3, \"string\", true, null]}"
+jsonTests : IO ()
+jsonTests = runTests
+  [ parseTestCmpShow
+      "JSON 1"
+      jsonToplevelValue
+      "[1,2,4,[5,6],null,{\"some\":[\"object\"]},false]"
+      "[1, 2, 4, [5, 6], null, {\"some\": [\"object\"]}, false]"
+  , parseTestCmpShow
+      "JSON 2"
+      jsonToplevelValue
+      "{\n  \"hallo\":42,\"nichts\":null}"
+      "{\"hallo\": 42, \"nichts\": null}"
+
+  , parseTestCmpShow
+      "JSON 3"
+      jsonToplevelValue
+      "{\"hello\": [{\"world\": false}, 3, \"string\", true, null]}"
+      "{\"hello\": [{\"world\": false}, 3, \"string\", true, null]}"
+
+  , parseTestCmpNot
+      "JSON 4"
+      jsonToplevelValue
+      "{{\n  \"hallo\":42,\"nichts\":null}"
+      """at 1:1 expected:
+  character '['
+at 1:1 expected:
+  a different token
+at 1:2 expected:
+  character '}'
+at 1:2 expected:
+  a different token
+"""
+  ]

--- a/tests/Test.idr
+++ b/tests/Test.idr
@@ -1,4 +1,4 @@
-module Main
+module Test
 
 import Data.Vect
 import Data.Fin
@@ -6,11 +6,9 @@ import Data.Fin
 import Lightyear
 import Lightyear.Char
 import Lightyear.Strings
+import Lightyear.Testing
 
-test : Show a => Parser a -> String -> IO ()
-test p input = case parse p input of
-  Left  e => putStrLn e
-  Right x => printLn x
+%access export
 
 listOf : Parser a -> Parser (List a)
 listOf p = string "[" *!> (p `sepBy` string ",") <* string "]"
@@ -21,14 +19,32 @@ listOf' p = brackets (commaSep p)
 nat : Parser Nat
 nat = integer
 
-main : IO ()
-main = do
-  test nat "123"
-  test (listOf nat) "[1,2,3,99]"
-  test (listOf nat) "foo"
-  test (listOf nat <|> (string "[foo" *> pure List.Nil)) "[foo"  -- should commit and fail
-  test (listOf $ listOf nat) "[[1,2],[],[3,4,5]]"
+tests : IO ()
+tests = runTests
+  [ parseTestCmp "Test 1" nat          (==) "123"        123
+  , parseTestCmp "Test 2" (listOf nat) (==) "[1,2,3,99]" [1,2,3,99]
 
-  test (listOf' nat) "[1,2,3,99]"
-  test (listOf' $ listOf' nat) "[[1,2],[],[3,4,5]]"
-  test (listOf' nat <|> (string "[foo" *> pure List.Nil)) "[foo"  -- should commit and fail
+  , parseTestCmpNot "Test 3" (listOf nat) "foo" """at 1:1 expected:
+  string "["
+at 1:1 expected:
+  character '['
+at 1:1 expected:
+  a different token
+"""
+
+  -- should commit and fail
+  , parseTestCmpNot "Test 4" (listOf nat <|> (string "[foo" *> pure List.Nil)) "[foo" """at 1:2 expected:
+  string "]"
+at 1:2 expected:
+  character ']'
+at 1:2 expected:
+  a different token
+"""
+
+  , parseTestCmp "Test 5" (listOf $ listOf nat)   (==) "[[1,2],[],[3,4,5]]" [[1, 2], [], [3, 4, 5]]
+  , parseTestCmp "Test 6" (listOf' nat)           (==) "[1,2,3,99]"         [1, 2, 3, 99]
+  , parseTestCmp "Test 6" (listOf' $ listOf' nat) (==) "[[1,2],[],[3,4,5]]" [[1, 2], [], [3, 4, 5]]
+
+  -- should commit and fail
+  , parseTestCmp "Test 7" (listOf' nat <|> (string "[foo" *> pure List.Nil)) (==) "[foo" []
+  ]

--- a/tests/expected
+++ b/tests/expected
@@ -1,29 +1,12 @@
-123
-[1, 2, 3, 99]
-at 1:1 expected:
-  string "["
-at 1:1 expected:
-  character '['
-at 1:1 expected:
-  a different token
-at 1:2 expected:
-  string "]"
-at 1:2 expected:
-  character ']'
-at 1:2 expected:
-  a different token
-[[1, 2], [], [3, 4, 5]]
-[1, 2, 3, 99]
-[[1, 2], [], [3, 4, 5]]
-[]
-[1, 2, 4, [5, 6], null, {"some": ["object"]}, false]
-{"hallo": 42, "nichts": null}
-error: at 1:1 expected:
-  character '['
-at 1:1 expected:
-  a different token
-at 1:2 expected:
-  character '}'
-at 1:2 expected:
-  a different token
-{"hello": [{"world": false}, 3, "string", true, null]}
+[PASS] JSON 1
+[PASS] JSON 2
+[PASS] JSON 3
+[PASS] JSON 4
+[PASS] Test 1
+[PASS] Test 2
+[PASS] Test 3
+[PASS] Test 4
+[PASS] Test 5
+[PASS] Test 6
+[PASS] Test 6
+[PASS] Test 7

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -19,22 +19,23 @@ die() {
 }
 
 clean_up() {
-	rm -f *.ibc test json output
+    idris --clean test.ipkg
+	rm -f *.ibc output
 }
 
 clean_up
 
 echo "compiling lightyear tests..."
-idris Test.idr -p lightyear -o test || die "* could not compile tests *"
+idris --build test.ipkg || die "* could not compile tests *"
 
 echo "compiled OK, running lightyear tests..."
-$TIMEOUTCMD 5s ./test > output || die "* test failed or timed out *"
+$TIMEOUTCMD 30s idris --testpkg test.ipkg | grep -v -e "idris" > output || die "* test failed or timed out *"
 
-echo "compiling the JSON test..."
-idris JsonTest.idr -p lightyear -p contrib -o json || die "* could not compile the json test *"
-
-echo "compiled OK, running the JSON test..."
-$TIMEOUTCMD 5s ./json >> output || die "* test failed or timed out *"
+#echo "compiling the JSON test..."
+#idris JsonTest.idr -p lightyear -p contrib -o json || die "* could not compile the json test *"
+#
+#echo "compiled OK, running the JSON test..."
+#$TIMEOUTCMD 5s ./json >> output || die "* test failed or timed out *"
 
 # use a default parameter if $1 is not set
 if [ "${1-}" = "believe_me" ]; then

--- a/tests/test.ipkg
+++ b/tests/test.ipkg
@@ -1,0 +1,10 @@
+package test
+
+opts = "--sourcepath ../ --idrispath ../ -p contrib"
+
+modules = Json
+        , JsonTest
+        , Test
+
+tests = JsonTest.jsonTests
+      , Test.tests


### PR DESCRIPTION
I have contributed some of my external testing tools for Lightyear parsers.
They allow for testing successful and unsuccessful use of parsing, and
provision of pretty printing of passing and failing tests. Failing is
seen as either a parse failure or wrong result failure.

Using the added parsing tests, Lightyear's tests have been
internalised and rewritten as an Idris package test. This makes
compilation and reporting of tests easier.

I haven't added the tests to Lightyear itself, although that is
possible.

We have also asked Idris to use Lightyear directly. This means we
no longer have to install lightyear to test it.