### PR TITLE
Alter the types for opening and closing parsers in `between`

### DIFF
--- a/Lightyear/Combinators.idr
+++ b/Lightyear/Combinators.idr
@@ -164,7 +164,7 @@ opt p = map Just p <|> pure Nothing
 ||| @close The closing parser.
 ||| @p The parser for the middle part.
 between : Monad m => (open : ParserT str m a)
-                  -> (close : ParserT str m a)
+                  -> (close : ParserT str m c)
                   -> (p : ParserT str m b)
                   -> ParserT str m b
 between open close p = open *> p <* close


### PR DESCRIPTION
There's no point in requiring them to be the same, the values are discarded anyway.